### PR TITLE
Enable GitHub Actions CI

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -1,0 +1,34 @@
+#Originally from https://raw.githubusercontent.com/k8snetworkplumbingwg/sriov-cni/master/.github/workflows/buildtest.yml
+name: Go-build-and-test-amd64
+on:
+    push:
+    pull_request:
+    schedule:
+      - cron: "0 8 * * 0" # every sunday
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x, 1.15.x, 1.16.x]
+        os: [ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: on
+      TARGET: amd64
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: GOARCH="${TARGET}" make build
+
+      - name: Lint
+        run: make lint
+
+      - name: Go test
+        run:  make test

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -1,0 +1,33 @@
+name: "Push images on merge to master"
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-push-imag-ib-sriov-cni:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ib-sriov-cni
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          file: ./Dockerfile

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -1,0 +1,39 @@
+name: "Push images on release"
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  build-and-push-image-ib-sriov-cni:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tag-latest: false
+
+      - name: Build and push ib-sriov-cni
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          file: ./Dockerfile


### PR DESCRIPTION
This patch introduces following CI jobs:
* lint, build and unit-test run
* publish image to GHCR on each merge
* publish image to GHCR on each release